### PR TITLE
Go 1.18: rewrite `interface{}` to `any`

### DIFF
--- a/pkg/osutil/dns_darwin.go
+++ b/pkg/osutil/dns_darwin.go
@@ -26,7 +26,7 @@ func DNSAddresses() ([]string, error) {
 	return addresses, nil
 }
 
-func proxyURL(proxy string, port interface{}) string {
+func proxyURL(proxy string, port any) string {
 	if !strings.Contains(proxy, "://") {
 		proxy = "http://" + proxy
 	}

--- a/pkg/sysprof/network_darwin.go
+++ b/pkg/sysprof/network_darwin.go
@@ -20,17 +20,17 @@ type IPv4 struct {
 }
 
 type Proxies struct {
-	ExceptionList []string    `json:"ExceptionList"` // default: ["*.local", "169.254/16"]
-	FTPEnable     string      `json:"FTPEnable"`
-	FTPPort       interface{} `json:"FTPPort"`
-	FTPProxy      string      `json:"FTPProxy"`
-	FTPUser       string      `json:"FTPUser"`
-	HTTPEnable    string      `json:"HTTPEnable"`
-	HTTPPort      interface{} `json:"HTTPPort"`
-	HTTPProxy     string      `json:"HTTPProxy"`
-	HTTPUser      string      `json:"HTTPUser"`
-	HTTPSEnable   string      `json:"HTTPSEnable"`
-	HTTPSPort     interface{} `json:"HTTPSPort"`
-	HTTPSProxy    string      `json:"HTTPSProxy"`
-	HTTPSUser     string      `json:"HTTPSUser"`
+	ExceptionList []string `json:"ExceptionList"` // default: ["*.local", "169.254/16"]
+	FTPEnable     string   `json:"FTPEnable"`
+	FTPPort       any      `json:"FTPPort"`
+	FTPProxy      string   `json:"FTPProxy"`
+	FTPUser       string   `json:"FTPUser"`
+	HTTPEnable    string   `json:"HTTPEnable"`
+	HTTPPort      any      `json:"HTTPPort"`
+	HTTPProxy     string   `json:"HTTPProxy"`
+	HTTPUser      string   `json:"HTTPUser"`
+	HTTPSEnable   string   `json:"HTTPSEnable"`
+	HTTPSPort     any      `json:"HTTPSPort"`
+	HTTPSProxy    string   `json:"HTTPSProxy"`
+	HTTPSUser     string   `json:"HTTPSUser"`
 }

--- a/pkg/templateutil/templateutil.go
+++ b/pkg/templateutil/templateutil.go
@@ -5,7 +5,7 @@ import (
 	"text/template"
 )
 
-func Execute(tmpl string, args interface{}) ([]byte, error) {
+func Execute(tmpl string, args any) ([]byte, error) {
 	x, err := template.New("").Parse(tmpl)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Rewrites `interface{}` to `any` using `gofmt`

[_Created by Sourcegraph batch change `christine/Go-upgrade-type`._](https://demo.sourcegraph.com/users/christine/batch-changes/Go-upgrade-type)